### PR TITLE
feat: initial release of DraftMk template for project scaffolding

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jonatan Mata
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # draftmk-copier-templates
-Copier templates for DraftMk projects. Used by the draftmk-cli to scaffold new documentation projects.
+
+This repository contains official Copier templates for [DraftMk](https://pypi.org/project/draftmk/) projects.
+
+These templates are automatically used by the `draftmk` CLI to scaffold new MkDocs-based documentation projects with Docker, Vite, and Markdown enhancements.
+
+## Features
+
+- Standardized MkDocs configuration
+- Predefined project folder structure
+- Vite integration and environment support
+- Copier-powered prompts for customization
+
+## Usage
+
+### With the `draftmk` CLI
+
+Install DraftMk and initialize a new project:
+
+```bash
+pip install draftmk
+draftmk init
+```
+
+## Template Configuration
+
+The `copier.yml` file defines the following configuration prompts:
+
+- `project_name`: Display name for your site
+- `repo_name`: GitHub repository path (e.g. `your-org/your-repo`)
+- `site_url`: Base URL of your site (for MkDocs config)
+- `vite_env`: Frontend environment (e.g. `production`, `staging`)
+
+## License
+
+MIT © [Jonatan Mata](https://jonmatum.dev)
+
+---
+
+```bash
+echo "Pura Vida & Happy Coding!";
+```

--- a/copier.yml
+++ b/copier.yml
@@ -1,0 +1,25 @@
+_exclude:
+  - ".git"
+  - "copier.yml"
+  - "LICENSE"
+  
+project_name:
+  type: str
+  default: "MkDocs + DraftMk"
+  help: "Project name (used for documentation site name)"
+
+repo_name:
+  type: str
+  default: "TODO:your-org/your-repo"
+  help: "GitHub repository name (e.g. jonmatum/draftmk-docs)"
+
+site_url:
+  type: str
+  default: "TODO:https://example.com"
+  help: "Base URL for your site (used in MkDocs config)"
+
+vite_env:
+  type: str
+  default: "production"
+  help: "Frontend environment mode"
+

--- a/docker-compose.yml.jinja
+++ b/docker-compose.yml.jinja
@@ -1,0 +1,56 @@
+services:
+  backend:
+    image: jonmatum/draftmk-backend:latest
+    environment:
+      APP_ENV: local
+      MODULE_NAME: app.main
+      VARIABLE_NAME: app
+      GITHUB_TOKEN: ${GITHUB_TOKEN}
+      GITHUB_REPO: ${GITHUB_REPO}
+      GITHUB_BRANCH: ${GITHUB_BRANCH}
+      CONTENT_DIR: docs
+    ports:
+      - "${BACKEND_PORT:-8888}:8888"
+    volumes:
+      - .draftmk/config:/app/config:cached
+      - ./docs:/app/docs:cached
+      - .draftmk/site:/app/site:cached
+      - .:/repo:cached
+      - ~/.ssh:/root/.ssh:ro
+      - ~/.gitconfig:/root/.gitconfig:ro
+      - ~/.git-credentials:/root/.git-credentials:ro
+    networks:
+      - draftmk-net
+    healthcheck:
+      disable: true
+    restart: unless-stopped
+
+  frontend:
+    image: jonmatum/draftmk-frontend:latest
+    environment:
+      VITE_API_BASE_URL: ${VITE_API_BASE_URL}
+      VITE_DOCS_PREVIEW_BASE_URL: ${VITE_DOCS_PREVIEW_BASE_URL}
+      VITE_ENVIRONMENT: ${VITE_ENVIRONMENT}
+    entrypoint: ["/entrypoint.sh"]
+    ports:
+      - "${FRONTEND_PORT:-80}:80"
+    networks:
+      - draftmk-net
+    healthcheck:
+      disable: true
+    restart: unless-stopped
+
+  preview:
+    image: jonmatum/draftmk-preview:latest
+    ports:
+      - "${PREVIEW_PORT:-8080}:8080"
+    volumes:
+      - .draftmk/site/public:/usr/share/nginx/html/public:ro
+      - .draftmk/site/internal:/usr/share/nginx/html/internal:ro
+    networks:
+      - draftmk-net
+    restart: unless-stopped
+
+networks:
+  draftmk-net:
+    driver: bridge

--- a/docs/index.md.jinja
+++ b/docs/index.md.jinja
@@ -1,0 +1,8 @@
+---
+title: Welcome
+role: public
+---
+
+# Welcome to {{ project_name }}
+
+This is your documentation homepage. Edit `index.md` to get started.


### PR DESCRIPTION
This release adds the first version of the official DraftMk Copier template, designed to scaffold MkDocs-based documentation projects via the `draftmk` CLI.

Includes:
- `copier.yml` with prompts for project name, repo, URL, environment.
- Default configuration supporting internal and remote usage.
- Compatible with DraftMk CLI ≥0.8.0.

Usage is intended through the `draftmk init` command, not standalone Copier usage.